### PR TITLE
VIVI-14351 Fix clock logo scaling

### DIFF
--- a/src/Clock.jsx
+++ b/src/Clock.jsx
@@ -195,7 +195,7 @@ export default function Clock({
       <svg
         fill="none"
         height="33"
-        style={{ transform: `translateX(calc(${size / 2}px - 50%)) translateY(calc(-${size / 8}px - 50%))` }}
+        style={{ transform: `translateX(calc(${size / 2}px - 50%)) translateY(calc(-${(2 * size) / 3}px))` }}
         viewBox="0 0 32 33"
         width="32"
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Since fixing the clock to remove the shadows, adjustments were made to the Vivi logo which put it out of position when rescaling the clock. Some playing around with the size parameter reveals that this is the correct position to leave it in.